### PR TITLE
two-armed design included

### DIFF
--- a/R/DataDistribution.R
+++ b/R/DataDistribution.R
@@ -9,6 +9,11 @@
 #' approximation of a binary endpoint.
 #' Currently, only the normal case is implemented with \code{\link{Normal-class}}.
 #'
+#' The logical option \code{two_armed} allows to decide whether a one-arm or
+#' a two-arm (the default) design should be computed. In the case of a two-arm
+#' design the function \code{\link{plot}} and \code{\link{summary}} describe
+#' the sample size per group.
+#'
 #' @slot two_armed Should a two-armed design be used?
 #'
 #' @template DataDistributionTemplate
@@ -56,6 +61,8 @@ setMethod("cumulative_distribution_function", signature("DataDistribution", "num
 #' and stage size.
 #' Standard deviation is 1 and mean \eqn{\theta\sqrt n} where
 #' \eqn{\theta} is the standardized effect size.
+#' The option \code{two_armed} can be set to decide whether a one-arm or a
+#' two-arm design should be computed.
 #' See \code{\link{DataDistribution-class}} for more details.
 #'
 #' @template DataDistributionTemplate

--- a/R/DataDistribution.R
+++ b/R/DataDistribution.R
@@ -9,15 +9,20 @@
 #' approximation of a binary endpoint.
 #' Currently, only the normal case is implemented with \code{\link{Normal-class}}.
 #'
+#' @slot two_armed Should a two-armed design be used?
+#'
 #' @template DataDistributionTemplate
 #'
 #' @exportClass DataDistribution
-setClass("DataDistribution")
+setClass("DataDistribution", representation(
+    two_armed = "logical")
+)
+
 
 #' @param probs numeric vector of probabilities
 #' @describeIn DataDistribution quantile function of the respective distribution.
 #' @export
-setMethod("quantile", signature("DataDistribution"), function(x, probs, n, theta, ...) stop("not implemented"))
+setMethod("quantile", signature("DataDistribution"), function(dist, x, probs, n, theta, ...) stop("not implemented"))
 
 
 #' @rdname DataDistribution-class
@@ -58,30 +63,44 @@ setMethod("cumulative_distribution_function", signature("DataDistribution", "num
 #' @rdname NormalDataDistribution-class
 #' @exportClass Normal
 setClass("Normal", representation(
-    dummy = "logical" # needed to make this non-abstract
+    two_armed = "logical"
     ),
     contains = "DataDistribution")
 
-
+#' @param two_armed s. slot
+#'
 #' @rdname NormalDataDistribution-class
 #' @export
-Normal <- function() new("Normal", dummy = FALSE)
+Normal <- function(two_armed = TRUE) new("Normal", two_armed = two_armed)
 
 
 #' @rdname NormalDataDistribution-class
 #' @export
 setMethod("probability_density_function", signature("Normal", "numeric", "numeric", "numeric"),
-          function(dist, x, n, theta, ...) stats::dnorm(x, mean = sqrt(n) * theta, sd = 1) )
+          function(dist, x, n, theta, ...){
+              theta <- ifelse(dist@two_armed == T, theta / sqrt(2), theta)
+              return(stats::dnorm(x, mean = sqrt(n) * theta, sd = 1))
+              }
+          )
 
 
 #' @rdname NormalDataDistribution-class
 #' @export
 setMethod("cumulative_distribution_function", signature("Normal", "numeric", "numeric", "numeric"),
-          function(dist, x, n, theta, ...) stats::pnorm(x, mean = sqrt(n) * theta, sd = 1) )
+          function(dist, x, n, theta, ...){
+              theta <- ifelse(dist@two_armed == T, theta / sqrt(2), theta)
+              return(stats::pnorm(x, mean = sqrt(n) * theta, sd = 1))
+              }
+          )
+
 
 
 #' @param probs vector of probabilities
 #' @rdname NormalDataDistribution-class
 #' @export
 setMethod("quantile", signature("Normal"),
-          function(x, probs, n, theta, ...) stats::qnorm(probs, mean = sqrt(n) * theta, sd = 1) )
+          function(dist, x, probs, n, theta, ...){
+              theta <- ifelse(dist@two_armed == T, theta / sqrt(2), theta)
+              return(stats::qnorm(probs, mean = sqrt(n) * theta, sd = 1))
+              }
+          )

--- a/man/DataDistribution-class.Rd
+++ b/man/DataDistribution-class.Rd
@@ -47,6 +47,11 @@ This abstraction layer allows representation of t-distributions
 (unknown variance), normal distribution (known variance), and normal
 approximation of a binary endpoint.
 Currently, only the normal case is implemented with \code{\link{Normal-class}}.
+
+The logical option \code{two_armed} allows to decide whether a one-arm or
+a two-arm (the default) design should be computed. In the case of a two-arm
+design the function \code{\link{plot}} and \code{\link{summary}} describe
+the sample size per group.
 }
 \section{Methods (by generic)}{
 \itemize{

--- a/man/DataDistribution-class.Rd
+++ b/man/DataDistribution-class.Rd
@@ -10,7 +10,7 @@
 \alias{cumulative_distribution_function,DataDistribution,numeric,numeric,numeric-method}
 \title{Data distributions}
 \usage{
-\S4method{quantile}{DataDistribution}(x, probs, n, theta, ...)
+\S4method{quantile}{DataDistribution}(dist, x, probs, n, theta, ...)
 
 probability_density_function(dist, x, n, theta, ...)
 
@@ -25,6 +25,8 @@ cumulative_distribution_function(dist, x, n, theta, ...)
   x, n, theta, ...)
 }
 \arguments{
+\item{dist}{data distribution object}
+
 \item{x}{outcome}
 
 \item{probs}{numeric vector of probabilities}
@@ -34,8 +36,6 @@ cumulative_distribution_function(dist, x, n, theta, ...)
 \item{theta}{distribution parameter}
 
 \item{...}{further optional arguments}
-
-\item{dist}{data distribution object}
 }
 \description{
 \code{DataDistribution} is an abstract class used to represent the distribution
@@ -57,5 +57,11 @@ sample size and parameter; must be implemented.
 
 \item \code{cumulative_distribution_function}: cumulative distribution function given outcome,
 sample size and parameter; must be implemented.
+}}
+
+\section{Slots}{
+
+\describe{
+\item{\code{two_armed}}{Should a two-armed design be used?}
 }}
 

--- a/man/NormalDataDistribution-class.Rd
+++ b/man/NormalDataDistribution-class.Rd
@@ -9,7 +9,7 @@
 \alias{quantile,Normal-method}
 \title{Normal data distribution}
 \usage{
-Normal()
+Normal(two_armed = TRUE)
 
 
   \S4method{probability_density_function}{Normal,numeric,numeric,numeric}(dist,
@@ -19,9 +19,11 @@ Normal()
   \S4method{cumulative_distribution_function}{Normal,numeric,numeric,numeric}(dist,
   x, n, theta, ...)
 
-\S4method{quantile}{Normal}(x, probs, n, theta, ...)
+\S4method{quantile}{Normal}(dist, x, probs, n, theta, ...)
 }
 \arguments{
+\item{two_armed}{s. slot}
+
 \item{dist}{data distribution object}
 
 \item{x}{outcome}

--- a/man/NormalDataDistribution-class.Rd
+++ b/man/NormalDataDistribution-class.Rd
@@ -41,5 +41,7 @@ Implements a normal data distribution for z-values given an observed z-value
 and stage size.
 Standard deviation is 1 and mean \eqn{\theta\sqrt n} where
 \eqn{\theta} is the standardized effect size.
+The option \code{two_armed} can be set to decide whether a one-arm or a
+two-arm design should be computed.
 See \code{\link{DataDistribution-class}} for more details.
 }

--- a/tests/testthat/test_GSDesign.R
+++ b/tests/testthat/test_GSDesign.R
@@ -31,7 +31,7 @@ test_that("Optimal group-sequential design with point prior is computable", {
     null        <- PointMassPrior(.0, 1)
     alternative <- PointMassPrior(.4, 1)
 
-    dist <- Normal()
+    dist <- Normal(two_armed = F)
 
     ess  <- integrate(ConditionalSampleSize(dist, alternative))
     cp   <- ConditionalPower(dist, alternative)

--- a/tests/testthat/test_OneStageDesign.R
+++ b/tests/testthat/test_OneStageDesign.R
@@ -32,7 +32,7 @@ test_that("Optimal one-stage design with point prior is computable", {
     null        <- PointMassPrior(.0, 1)
     alternative <- PointMassPrior(.4, 1)
 
-    dist <- Normal()
+    dist <- Normal(two_armed = F)
 
     ess  <- integrate(ConditionalSampleSize(dist, alternative))
     cp   <- ConditionalPower(dist, alternative)

--- a/tests/testthat/test_PointMassPrior.R
+++ b/tests/testthat/test_PointMassPrior.R
@@ -2,7 +2,7 @@ context("PointMassPrior                                                       ")
 
 test_that("single point prior", {
 
-    dist <- Normal()
+    dist <- Normal(two_armed=F)
 
     prior <- PointMassPrior(.0, 1.0)
 
@@ -70,7 +70,7 @@ test_that("single point prior", {
 
 test_that("multiple points prior", {
 
-    dist <- Normal()
+    dist <- Normal(two_armed=F)
 
     prior <- PointMassPrior(c(.0, .5), c(.5, .5))
 

--- a/tests/testthat/test_constraints.R
+++ b/tests/testthat/test_constraints.R
@@ -8,7 +8,7 @@ test_that("UnconditionalConstraints", {
     design <- gq_design(25, 0, 2, rep(40.0, 5), rep( 1.96, 5), 5L)
 
     # create power as IntegralScore
-    pow <- integrate(ConditionalPower(Normal(), PointMassPrior(.4, 1)))
+    pow <- integrate(ConditionalPower(Normal(two_armed=F), PointMassPrior(.4, 1)))
 
     # construct actual constraint
     cnstr <- pow >= 0.8
@@ -18,7 +18,7 @@ test_that("UnconditionalConstraints", {
         evaluate(cnstr, design), -0.0415, tolerance = .001)
 
     # check other direction
-    toer <- integrate(ConditionalPower(Normal(), PointMassPrior(.0, 1)))
+    toer <- integrate(ConditionalPower(Normal(two_armed=F), PointMassPrior(.0, 1)))
     expect_equal(
         evaluate(toer <= .05, design), -.0153, tolerance = .001)
 
@@ -30,7 +30,7 @@ test_that("ConditionalConstraints", {
     design <- gq_design(25, 0, 2, rep(40.0, 5), rep( 1.96, 5), 5L)
 
     # create power as IntegralScore
-    cp <- ConditionalPower(Normal(), PointMassPrior(.4, 1))
+    cp <- ConditionalPower(Normal(two_armed=F), PointMassPrior(.4, 1))
 
     # construct actual constraint
     cnstr <- cp >= 0.8
@@ -40,7 +40,7 @@ test_that("ConditionalConstraints", {
         evaluate(cnstr, design, .8), 0.0844, tolerance = .001)
 
     # check other direction
-    ctoer <- ConditionalPower(Normal(), PointMassPrior(.0, 1))
+    ctoer <- ConditionalPower(Normal(two_armed=F), PointMassPrior(.0, 1))
     expect_equal(
         evaluate(ctoer <= .05, design, .8), -.0250, tolerance = .001)
 
@@ -53,7 +53,7 @@ test_that("ConditionalConstraints", {
     design <- gq_design(25, 0, 2, rep(40.0, 5), rep( 1.96, 5), 5L)
 
     # create power as IntegralScore
-    cp <- ConditionalPower(Normal(), PointMassPrior(.4, 1))
+    cp <- ConditionalPower(Normal(two_armed=F), PointMassPrior(.4, 1))
 
     # construct a constraint set and see if it is at least of the right length
     expect_equal(

--- a/tests/testthat/test_tunable.R
+++ b/tests/testthat/test_tunable.R
@@ -14,7 +14,7 @@ design <- gq_design(n1, c1f, c1e, n2_piv, c2_piv, order)
 null        <- PointMassPrior(.0, 1)
 alternative <- PointMassPrior(.4, 1)
 
-dist <- Normal()
+dist <- Normal(two_armed = F)
 
 ess  <- integrate(ConditionalSampleSize(dist, alternative))
 cp   <- ConditionalPower(dist, alternative)


### PR DESCRIPTION
The possibility of a two-arm design was included and used as default value.

I changed the test for TwoStageDesign to equal to the example we analysed in our previous manuscript. Therefore, we have solutions we know to be correct.